### PR TITLE
fix: next@canaryをインストールしてSWCに関するエラーを解決

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "axios": "^1.3.6",
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
-    "next": "13.3.0",
+    "next": "^13.3.5-canary.8",
     "postcss": "8.4.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
`Failed to load SWC binary for linux/x64` のエラーを対処