### PR TITLE
保存機能追加 (POSTメソッドで現在のESの状態を送信)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "axios": "^1.3.6",
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
-    "next": "^13.3.5-canary.8",
+    "next": "^13.4.3-canary.1",
     "postcss": "8.4.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/frontend/src/components/editing/EditingEntrysheet.tsx
+++ b/frontend/src/components/editing/EditingEntrysheet.tsx
@@ -41,7 +41,12 @@ const EditingEntrysheet = (props: {
     <div className="p-4 flex flex-col ">
       <Header company={company} job={job} event={event} />
       {Object.keys(entrysheet.questions).map((qId) => (
-        <QandA key={qId} qAndAProps={entrysheet.questions[qId]} />
+        <QandA
+          key={qId}
+          qId={qId}
+          qAndAProps={entrysheet.questions[qId]}
+          setEntrysheet={setEntrysheet}
+        />
       ))}
       <AddQandAButton
         questions={entrysheet.questions}

--- a/frontend/src/components/editing/EditingEntrysheet.tsx
+++ b/frontend/src/components/editing/EditingEntrysheet.tsx
@@ -34,7 +34,13 @@ const EditingEntrysheet = (props: {
 
   // 質問追加時にステートの状態を変更する関数
   const handleAddQandAs = (newQuestionProps: QuestionsProps) => {
-    setEntrysheet((prevQandAs) => ({ ...prevQandAs, ...newQuestionProps }));
+    setEntrysheet((prevEntrysheet) => ({
+      ...prevEntrysheet,
+      questions: {
+        ...prevEntrysheet.questions,
+        ...newQuestionProps,
+      },
+    }));
   };
 
   return (

--- a/frontend/src/components/editing/EditingEntrysheet.tsx
+++ b/frontend/src/components/editing/EditingEntrysheet.tsx
@@ -21,13 +21,16 @@ const EditingEntrysheet = (props: {
     questions: {},
   });
 
-  // questionsの値によってentrysheetを更新する
   useEffect(() => {
-    setEntrysheet((prevEntrySheet) => ({
-      ...prevEntrySheet,
+    setEntrysheet({
+      esId: esId,
+      company: company,
+      job: job,
+      event: event,
+      deadline: deadline,
       questions: { ...questions },
-    }));
-  }, [questions]);
+    });
+  }, [esId, company, job, event, deadline, questions]);
 
   if (!entrysheet) {
     return <div>Loading...</div>;

--- a/frontend/src/components/editing/EditingEntrysheet.tsx
+++ b/frontend/src/components/editing/EditingEntrysheet.tsx
@@ -6,6 +6,7 @@ import type {
 import Header from "./Header";
 import QandA from "./QandA";
 import AddQandAButton from "./buttons/AddQandAButton";
+import SaveEntrysheetButton from "./buttons/SaveEntrysheetButton";
 
 const EditingEntrysheet = (props: {
   entrysheet: RichEntrysheetProps;
@@ -63,6 +64,7 @@ const EditingEntrysheet = (props: {
         questions={entrysheet.questions}
         setNewProps={handleAddQandAs}
       />
+      <SaveEntrysheetButton entrysheet={entrysheet} />
     </div>
   );
 };

--- a/frontend/src/components/editing/EditingEntrysheet.tsx
+++ b/frontend/src/components/editing/EditingEntrysheet.tsx
@@ -45,7 +45,12 @@ const EditingEntrysheet = (props: {
 
   return (
     <div className="p-4 flex flex-col ">
-      <Header company={company} job={job} event={event} />
+      <Header
+        company={company}
+        job={job}
+        event={event}
+        setEntrysheet={setEntrysheet}
+      />
       {Object.keys(entrysheet.questions).map((qId) => (
         <QandA
           key={qId}

--- a/frontend/src/components/editing/EditingEntrysheet.tsx
+++ b/frontend/src/components/editing/EditingEntrysheet.tsx
@@ -11,29 +11,42 @@ const EditingEntrysheet = (props: {
   entrysheet: RichEntrysheetProps;
 }): JSX.Element => {
   const { esId, company, job, event, deadline, questions } = props.entrysheet;
-  const [qAndAs, setQandAs] = useState<QuestionsProps>({});
+  const [entrysheet, setEntrysheet] = useState<RichEntrysheetProps>({
+    esId: esId,
+    company: company,
+    job: job,
+    event: event,
+    deadline: deadline,
+    questions: {},
+  });
 
-  // questionsの値によってレンダリングを再実行
+  // questionsの値によってentrysheetを更新する
   useEffect(() => {
-    setQandAs({ ...questions });
+    setEntrysheet((prevEntrySheet) => ({
+      ...prevEntrySheet,
+      questions: { ...questions },
+    }));
   }, [questions]);
 
-  if (!qAndAs) {
+  if (!entrysheet) {
     return <div>Loading...</div>;
   }
 
   // 質問追加時にステートの状態を変更する関数
   const handleAddQandAs = (newQuestionProps: QuestionsProps) => {
-    setQandAs((prevQandAs) => ({ ...prevQandAs, ...newQuestionProps }));
+    setEntrysheet((prevQandAs) => ({ ...prevQandAs, ...newQuestionProps }));
   };
 
   return (
     <div className="p-4 flex flex-col ">
       <Header company={company} job={job} event={event} />
-      {Object.keys(qAndAs).map((qId) => (
-        <QandA key={qId} qAndAProps={qAndAs[qId]} />
+      {Object.keys(entrysheet.questions).map((qId) => (
+        <QandA key={qId} qAndAProps={entrysheet.questions[qId]} />
       ))}
-      <AddQandAButton questions={qAndAs} setNewProps={handleAddQandAs} />
+      <AddQandAButton
+        questions={entrysheet.questions}
+        setNewProps={handleAddQandAs}
+      />
     </div>
   );
 };

--- a/frontend/src/components/editing/Header.tsx
+++ b/frontend/src/components/editing/Header.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from "react";
 import CompanyForm from "./forms/CompanyForm";
 import MetaForm from "./forms/MetaForm";
+import type { RichEntrysheetProps } from "@/types/EntrysheetProps";
 
 const Header = (props: {
   company: string;
   job: string;
   event: string;
+  setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
 }): JSX.Element => {
   const [company, setCompany] = useState<string>("");
   const [job, setJob] = useState<string>("");
@@ -23,7 +25,7 @@ const Header = (props: {
   }
   return (
     <header className="flex flex-col border-b border-gray-300 pl-4">
-      <CompanyForm company={company} />
+      <CompanyForm company={company} setEntrysheet={props.setEntrysheet} />
       <MetaForm job={job} event={event} />
     </header>
   );

--- a/frontend/src/components/editing/Header.tsx
+++ b/frontend/src/components/editing/Header.tsx
@@ -26,7 +26,7 @@ const Header = (props: {
   return (
     <header className="flex flex-col border-b border-gray-300 pl-4">
       <CompanyForm company={company} setEntrysheet={props.setEntrysheet} />
-      <MetaForm job={job} event={event} />
+      <MetaForm job={job} event={event} setEntrysheet={props.setEntrysheet} />
     </header>
   );
 };

--- a/frontend/src/components/editing/QandA.tsx
+++ b/frontend/src/components/editing/QandA.tsx
@@ -63,7 +63,12 @@ const QandA = (props: {
           <div className="ml-0.5">字以内</div>
         </div>
       </div>
-      <AnswerForms answers={answers} maxChars={maxChars} />
+      <AnswerForms
+        qId={qId}
+        answers={answers}
+        maxChars={maxChars}
+        setEntrysheet={setEntrysheet}
+      />
     </form>
   );
 };

--- a/frontend/src/components/editing/QandA.tsx
+++ b/frontend/src/components/editing/QandA.tsx
@@ -16,9 +16,11 @@ const QandA = (props: {
   const { qId, qAndAProps, setEntrysheet } = props;
   const question: string = qAndAProps.question;
   const answers: AnswersProps = qAndAProps.answers;
+
+  // answersコンポーネントに最大字数を共有するためのuseState
   const [maxChars, setMaxChars] = useState<number>(qAndAProps.maxChars);
 
-  // questionsの記入が終わったら書き換えを反映
+  // EditingEntrysheetのentrysheetに変更を反映させる
   const handleQuestionChange = (text: string): void => {
     setEntrysheet((prevEntrySheet: RichEntrysheetProps) => ({
       ...prevEntrySheet,
@@ -32,6 +34,20 @@ const QandA = (props: {
     }));
   };
 
+  // EditingEntrysheetのentrysheetに変更を反映させる
+  const handleMaxCharsChange = (chars: number): void => {
+    setEntrysheet((prevEntrySheet: RichEntrysheetProps) => ({
+      ...prevEntrySheet,
+      questions: {
+        ...prevEntrySheet.questions,
+        [qId]: {
+          ...prevEntrySheet.questions[qId],
+          maxChars: chars,
+        },
+      },
+    }));
+  };
+
   return (
     <form className="p-4 flex-grow justify-between border-b border-gray-300">
       <div className="flex w-full">
@@ -39,7 +55,11 @@ const QandA = (props: {
           <QuestionForm question={question} onChange={handleQuestionChange} />
         </div>
         <div className="ml-2 flex items-center flex-shrink-0 flex-grow-0 justify-self-end">
-          <SetCharsForm maxChars={maxChars} setMaxChars={setMaxChars} />
+          <SetCharsForm
+            maxChars={maxChars}
+            setMaxChars={setMaxChars}
+            handleMaxCharsChange={handleMaxCharsChange}
+          />
           <div className="ml-0.5">字以内</div>
         </div>
       </div>

--- a/frontend/src/components/editing/QandA.tsx
+++ b/frontend/src/components/editing/QandA.tsx
@@ -1,19 +1,42 @@
 import QuestionForm from "./forms/QuestionForm";
 import SetCharsForm from "./forms/SetCharsForm";
 import AnswerForms from "./forms/AnswerForms";
-import type { QandAProps, AnswersProps } from "@/types/EntrysheetProps";
+import type {
+  QandAProps,
+  AnswersProps,
+  RichEntrysheetProps,
+} from "@/types/EntrysheetProps";
 import { useState } from "react";
 
-const QandA = (props: { qAndAProps: QandAProps }) => {
-  const question: string = props.qAndAProps.question;
-  const answers: AnswersProps = props.qAndAProps.answers;
-  const [maxChars, setMaxChars] = useState<number>(props.qAndAProps.maxChars);
+const QandA = (props: {
+  qId: string;
+  qAndAProps: QandAProps;
+  setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
+}) => {
+  const { qId, qAndAProps, setEntrysheet } = props;
+  const question: string = qAndAProps.question;
+  const answers: AnswersProps = qAndAProps.answers;
+  const [maxChars, setMaxChars] = useState<number>(qAndAProps.maxChars);
+
+  // questionsの記入が終わったら書き換えを反映
+  const handleQuestionChange = (text: string): void => {
+    setEntrysheet((prevEntrySheet: RichEntrysheetProps) => ({
+      ...prevEntrySheet,
+      questions: {
+        ...prevEntrySheet.questions,
+        [qId]: {
+          ...prevEntrySheet.questions[qId],
+          question: text,
+        },
+      },
+    }));
+  };
 
   return (
     <form className="p-4 flex-grow justify-between border-b border-gray-300">
       <div className="flex w-full">
         <div className="w-10/12">
-          <QuestionForm question={question} />
+          <QuestionForm question={question} onChange={handleQuestionChange} />
         </div>
         <div className="ml-2 flex items-center flex-shrink-0 flex-grow-0 justify-self-end">
           <SetCharsForm maxChars={maxChars} setMaxChars={setMaxChars} />

--- a/frontend/src/components/editing/buttons/SaveEntrysheetButton.tsx
+++ b/frontend/src/components/editing/buttons/SaveEntrysheetButton.tsx
@@ -1,0 +1,33 @@
+import axios from "axios";
+import type { RichEntrysheetProps } from "@/types/EntrysheetProps";
+
+const SaveEntrysheetButton = (props: {
+  entrysheet: RichEntrysheetProps;
+}): JSX.Element => {
+  const handleClick = () => {
+    const { entrysheet } = props;
+    const endpoint: string = "/api/user/entrysheets/" + entrysheet.esId;
+    console.log(entrysheet);
+    axios
+      .post(endpoint, entrysheet, {
+        headers: { "Content-Type": "application/json" },
+      })
+      .then((response) => {
+        console.log(response);
+      })
+      .catch((error) => {
+        console.error("Error", error);
+      });
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+    >
+      Save
+    </button>
+  );
+};
+
+export default SaveEntrysheetButton;

--- a/frontend/src/components/editing/forms/AnswerForms.tsx
+++ b/frontend/src/components/editing/forms/AnswerForms.tsx
@@ -74,35 +74,22 @@ const AnswerForms = (props: {
   setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
 }): JSX.Element => {
   const { qId, answers, maxChars, setEntrysheet } = props;
-  const [answerData, setAnswerData] = useState<AnswersProps>({});
 
-  useEffect(() => {
-    setAnswerData({ ...answers });
-  }, [answers]);
-
-  // 質問フォームの追加を行う
-  // HACK: レンダリングに関するwarningが出る
+  // 解答フォームの追加を行う
   const handleAddAnswer = (newAnswerProps: AnswersProps) => {
-    setAnswerData((prevAnswerData) => {
-      const updatedAnswerData = {
-        ...prevAnswerData,
-        ...newAnswerProps,
-      };
-
-      setEntrysheet((prevEntrySheet: RichEntrysheetProps) => ({
-        ...prevEntrySheet,
-        questions: {
-          ...prevEntrySheet.questions,
-          [qId]: {
-            ...prevEntrySheet.questions[qId],
-            answers: {
-              ...updatedAnswerData,
-            },
+    setEntrysheet((prevEntrySheet: RichEntrysheetProps) => ({
+      ...prevEntrySheet,
+      questions: {
+        ...prevEntrySheet.questions,
+        [qId]: {
+          ...prevEntrySheet.questions[qId],
+          answers: {
+            ...prevEntrySheet.questions[qId].answers,
+            ...newAnswerProps,
           },
         },
-      }));
-      return updatedAnswerData; // 新しい状態を返す
-    });
+      },
+    }));
   };
 
   return (
@@ -113,7 +100,7 @@ const AnswerForms = (props: {
           qId={qId}
           aId={aId}
           answer={answers[aId]}
-          maxChars={props.maxChars}
+          maxChars={maxChars}
           setEntrysheet={setEntrysheet}
         />
       ))}

--- a/frontend/src/components/editing/forms/CompanyForm.tsx
+++ b/frontend/src/components/editing/forms/CompanyForm.tsx
@@ -1,16 +1,31 @@
 import { useState } from "react";
 import DoubleClickForm from "./DoubleClickForm";
+import { RichEntrysheetProps } from "@/types/EntrysheetProps";
 
-const CompanyForm = (props: { company: string }) => {
-  const { company } = props;
+const CompanyForm = (props: {
+  company: string;
+  setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
+}) => {
+  const { company, setEntrysheet } = props;
   const classNames: string[] = [
     "px-2 py-1 rounded-lg border border-gray-300 bg-transparent",
     "text-lg font-bold",
   ];
 
+  const handleCompanyChange = (text: string): void => {
+    setEntrysheet((prevEntrysheet: RichEntrysheetProps) => ({
+      ...prevEntrysheet,
+      company: text,
+    }));
+  };
+
   return (
     <div className="flex items-center justify-starth-16">
-      <DoubleClickForm text={company} classNames={classNames} />
+      <DoubleClickForm
+        text={company}
+        classNames={classNames}
+        onChange={handleCompanyChange}
+      />
     </div>
   );
 };

--- a/frontend/src/components/editing/forms/DoubleClickForm.tsx
+++ b/frontend/src/components/editing/forms/DoubleClickForm.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 const DoubleClickForm = (props: {
   text: string;
   classNames: string[];
+  onChange: (text: string) => void;
 }): JSX.Element => {
   const [text, setText] = useState<string>(props.text);
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -22,6 +23,7 @@ const DoubleClickForm = (props: {
   const handleBlur = () => {
     setText(tempText);
     setIsEditing(false);
+    props.onChange(tempText); // entrysheetにtextを反映させる
   };
 
   return (

--- a/frontend/src/components/editing/forms/MetaForm.tsx
+++ b/frontend/src/components/editing/forms/MetaForm.tsx
@@ -1,4 +1,5 @@
 import DoubleClickForm from "./DoubleClickForm";
+import type { RichEntrysheetProps } from "@/types/EntrysheetProps";
 
 const classNames: string[] = [
   "px-2 py-1 rounded-lg border border-gray-300 bg-transparent mt-1",
@@ -8,41 +9,81 @@ const wrapper: string = "mr-8 pr-8 flex justify-around items-center";
 const borderWrapper: string = wrapper + " border-r border-gray-300";
 const spanClassName: string = "mr-3 font-bold ";
 
-const JobForm = (props: { job: string }): JSX.Element => {
-  const { job } = props;
+const JobForm = (props: {
+  job: string;
+  setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
+}): JSX.Element => {
+  const { job, setEntrysheet } = props;
+
+  const handleJobChange = (text: string): void => {
+    setEntrysheet((prevEntrysheet: RichEntrysheetProps) => ({
+      ...prevEntrysheet,
+      job: text,
+    }));
+  };
+
   return (
     <div className={borderWrapper}>
       <span className={spanClassName}>職種:</span>
-      <DoubleClickForm text={job} classNames={classNames} />
+      <DoubleClickForm
+        text={job}
+        classNames={classNames}
+        onChange={handleJobChange}
+      />
     </div>
   );
 };
 
-const EventForm = (props: { event: string }): JSX.Element => {
-  const { event } = props;
+const EventForm = (props: {
+  event: string;
+  setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
+}): JSX.Element => {
+  const { event, setEntrysheet } = props;
+
+  const handleEventChange = (text: string): void => {
+    setEntrysheet((prevEntrysheet: RichEntrysheetProps) => ({
+      ...prevEntrysheet,
+      event: text,
+    }));
+  };
+
   return (
     <div className={borderWrapper}>
       <span className={spanClassName}>イベント:</span>
-      <DoubleClickForm text={event} classNames={classNames} />
+      <DoubleClickForm
+        text={event}
+        classNames={classNames}
+        onChange={handleEventChange}
+      />
     </div>
   );
 };
 
+// TODO: 仮のフォームなので完成させる
 const DeadlineForm = (): JSX.Element => {
+  const handleDeadlineChange = (text: string): void => {};
   return (
     <div className={wrapper}>
       <span className={spanClassName}>締切:</span>
-      <DoubleClickForm text={"ほげ"} classNames={classNames} />
+      <DoubleClickForm
+        text={"ほげ"}
+        classNames={classNames}
+        onChange={handleDeadlineChange}
+      />
     </div>
   );
 };
 
-const MetaForm = (props: { job: string; event: string }): JSX.Element => {
-  const { job, event } = props;
+const MetaForm = (props: {
+  job: string;
+  event: string;
+  setEntrysheet: React.Dispatch<React.SetStateAction<RichEntrysheetProps>>;
+}): JSX.Element => {
+  const { job, event, setEntrysheet } = props;
   return (
     <div className="flex justify-start items-center pb-2">
-      <JobForm job={job} />
-      <EventForm event={event} />
+      <JobForm job={job} setEntrysheet={setEntrysheet} />
+      <EventForm event={event} setEntrysheet={setEntrysheet} />
       <DeadlineForm />
     </div>
   );

--- a/frontend/src/components/editing/forms/QuestionForm.tsx
+++ b/frontend/src/components/editing/forms/QuestionForm.tsx
@@ -1,10 +1,14 @@
 import { useState } from "react";
 import validateInput from "@/utils/validateInputError";
 
-const QuestionForm = (props: { question: string }): JSX.Element => {
+const QuestionForm = (props: {
+  question: string;
+  onChange: (text: string) => void;
+}): JSX.Element => {
   const [text, setText] = useState<string>(props.question);
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [tempText, setTempText] = useState<string>("");
+  const handleQuestionChange = props.onChange;
 
   // DBに格納できる文字長であるか判別するために使用
   const [error, setError] = useState("");
@@ -23,6 +27,7 @@ const QuestionForm = (props: { question: string }): JSX.Element => {
   // フォーカスが外れたら編集完了
   const handleBlur = () => {
     setText(tempText);
+    handleQuestionChange(tempText);
     setIsEditing(false);
   };
 

--- a/frontend/src/components/editing/forms/SetCharsForm.tsx
+++ b/frontend/src/components/editing/forms/SetCharsForm.tsx
@@ -1,10 +1,15 @@
 const SetCharsForm = (props: {
   maxChars: number;
   setMaxChars: (value: number) => void;
+  handleMaxCharsChange: (chars: number) => void;
 }): JSX.Element => {
-  const { maxChars } = props;
+  const { maxChars, setMaxChars, handleMaxCharsChange } = props;
+
+  // TODO: NaN対策
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    props.setMaxChars(parseInt(e.target.value));
+    const chars = parseInt(e.target.value);
+    setMaxChars(chars);
+    handleMaxCharsChange(chars);
   };
   return (
     <input

--- a/frontend/src/pages/api/user/entrysheets/0.ts
+++ b/frontend/src/pages/api/user/entrysheets/0.ts
@@ -5,31 +5,36 @@ const handler = (
   req: NextApiRequest,
   res: NextApiResponse<RichEntrysheetProps>
 ) => {
-  const entrysheet: RichEntrysheetProps = {
-    esId: "0",
-    company: "A株式会社",
-    job: "総合職",
-    event: "夏インターン",
-    deadline: "2023-03-31T12:00:00",
-    questions: {
-      "0": {
-        question: "志望動機は?",
-        maxChars: 400,
-        answers: {
-          "0": "とても楽しいそうだからです。",
-          "1": "アットホームだ",
+  if (req.method === "POST") {
+    const entrysheet = req.body; // リクエストボディからフォームデータを取得
+    res.status(200).json({ ...entrysheet });
+  } else {
+    const entrysheet: RichEntrysheetProps = {
+      esId: "0",
+      company: "A株式会社",
+      job: "総合職",
+      event: "夏インターン",
+      deadline: "2023-03-31T12:00:00",
+      questions: {
+        "0": {
+          question: "志望動機は?",
+          maxChars: 400,
+          answers: {
+            "0": "とても楽しいそうだからです。",
+            "1": "アットホームだ",
+          },
+        },
+        "1": {
+          question: "強みは?",
+          maxChars: 100,
+          answers: {
+            "0": "元気",
+          },
         },
       },
-      "1": {
-        question: "強みは?",
-        maxChars: 100,
-        answers: {
-          "0": "元気",
-        },
-      },
-    },
-  };
-  res.status(200).json(entrysheet);
+    };
+    res.status(200).json(entrysheet);
+  }
 };
 
 export default handler;


### PR DESCRIPTION
# やったこと
- #21 
- #24 

## 詳細
- `docker compose front up`で立ち上げして、[http://localhost:3001/user/entrysheets/0](http://localhost:3001/user/entrysheets/0)にアクセス
- デベロッパーツールでコンソールを見れる状態にする
- フォームを追加・変更してみて、`Save`ボタンを押すと、ちゃんと変更が反映されて送信されていることが確認できる

# TODO
- 解答保存ボタンのスタイルをちゃんと実装
- #20 

# HACK
- `setEntrysheet`がpropsのバケツリレーになっているからもう少し綺麗にできるかも
